### PR TITLE
chore: Add Cross.toml file

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,18 @@
+[target.x86_64-unknown-linux-musl]
+image = "jenoch/rust-cross:x86_64-unknown-linux-musl"
+
+[target.arm-unknown-linux-gnueabi]
+image = "jenoch/rust-cross:arm-unknown-linux-gnueabi"
+
+[target.arm-unknown-linux-gnueabihf]
+image = "jenoch/rust-cross:arm-unknown-linux-gnueabihf"
+
+[target.armv7-unknown-linux-gnueabihf]
+image = "jenoch/rust-cross:armv7-unknown-linux-gnueabihf"
+
+[target.aarch64-unknown-linux-gnu]
+image = "jenoch/rust-cross:aarch64-unknown-linux-gnu"
+
+[target.aarch64-unknown-linux-musl]
+image = "jenoch/rust-cross:aarch64-unknown-linux-musl"
+


### PR DESCRIPTION
See https://github.com/eclipse-zenoh/zenoh-ts/actions/runs/11668169163/job/32487293795#step:2:360, currently release workflow is failing because it can't find `Cross.toml` for cross-compilation