### PR TITLE
fix: adjust zenoh-plugin-remote-api LICENSE path

### DIFF
--- a/zenoh-plugin-remote-api/Cargo.toml
+++ b/zenoh-plugin-remote-api/Cargo.toml
@@ -87,5 +87,5 @@ name = "zenoh-plugin-remote-api"
 maintainer = "zenoh-dev@eclipse.org"
 copyright = "2024 ZettaScale Technology"
 section = "net"
-license-file = ["../../LICENSE", "0"]
+license-file = ["../zenoh-ts/LICENSE", "0"]
 depends = "zenohd (=0.11.0-dev-1)"


### PR DESCRIPTION
Otherwise `cargo-deb` fails like this: https://github.com/eclipse-zenoh/zenoh-ts/actions/runs/11720545273/job/32646148151#step:2:618