### PR TITLE
chore: rename ci.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
-name: Build TS and Plugin
+name: CI
 
 on:
   push:


### PR DESCRIPTION
Align with the rest of the repos in the eclipse-zenoh org