### PR TITLE
corrected API to make it similar to C++ which have the closest logic

### DIFF
--- a/zenoh-ts/examples/chat/src/chat_session.ts
+++ b/zenoh-ts/examples/chat/src/chat_session.ts
@@ -187,9 +187,7 @@ export class ChatSession {
 	async sendMessage(message: string) {
 		if (this.messages_publisher) {
 			log(`[Publisher] Put message: ${message}`);
-			await this.messages_publisher.put({
-				payload: message
-			});
+			await this.messages_publisher.put(message);
 		}
 	}
 

--- a/zenoh-ts/examples/chat/src/chat_session.ts
+++ b/zenoh-ts/examples/chat/src/chat_session.ts
@@ -113,8 +113,8 @@ export class ChatSession {
 		this.messages_publisher = this.session.declare_publisher(keyexpr, {});
 		log(`[Session] Declare publisher on ${keyexpr}`);
 
-		this.message_subscriber = await this.session.declare_subscriber("chat/user/*", {
-			handler: (sample) => {
+		this.message_subscriber = await this.session.declare_subscriber("chat/user/*",
+			(sample: Sample) => {
 				let message = deserialize_string(sample.payload().to_bytes());
 				log(`[Subscriber] Received message: ${message} from ${sample.keyexpr().toString()}`);
 				let user = ChatUser.fromKeyexpr(sample.keyexpr());
@@ -127,7 +127,7 @@ export class ChatSession {
 				}
 				return Promise.resolve();
 			}
-		});
+		);
 		log(`[Session] Declare Subscriber on chat/user/*`);
 
 		this.liveliness_token = this.session.liveliness().declare_token(keyexpr);

--- a/zenoh-ts/examples/deno/src/z_ping.ts
+++ b/zenoh-ts/examples/deno/src/z_ping.ts
@@ -34,7 +34,7 @@ export async function main() {
   const data = [122, 101, 110, 111, 104];
 
   while (elapsed(startTime) < 5) {
-    pub.put({ payload: data });
+    pub.put(data);
     await sub.receive();
   }
 
@@ -42,7 +42,7 @@ export async function main() {
   const samples_out = [];
   for (let i = 0; i < samples; i++) {
     const write_time = new Date();
-    pub.put({ payload: data });
+    pub.put(data);
     await sub.receive();
     samples_out.push(elapsed_ms(write_time));
   }

--- a/zenoh-ts/examples/deno/src/z_ping.ts
+++ b/zenoh-ts/examples/deno/src/z_ping.ts
@@ -18,7 +18,7 @@ import { Encoding, CongestionControl, Config, Session } from "@eclipse-zenoh/zen
 export async function main() {
   const session = await Session.open(new Config("ws/127.0.0.1:10000"));
 
-  const sub = session.declare_subscriber("test/pong", { handler: new FifoChannel(256) });
+  const sub = session.declare_subscriber("test/pong", new FifoChannel(256) );
   const pub = session.declare_publisher(
     "test/ping",
     {

--- a/zenoh-ts/examples/deno/src/z_pong.ts
+++ b/zenoh-ts/examples/deno/src/z_pong.ts
@@ -26,7 +26,7 @@ export async function main() {
   );
 
   const subscriber_callback = async function (sample: Sample): Promise<void> {
-    pub.put({ payload: sample.payload() });
+    pub.put(sample.payload());
   };
 
   session.declare_subscriber("test/pong", { handler: subscriber_callback });

--- a/zenoh-ts/examples/deno/src/z_pong.ts
+++ b/zenoh-ts/examples/deno/src/z_pong.ts
@@ -29,7 +29,7 @@ export async function main() {
     pub.put(sample.payload());
   };
 
-  session.declare_subscriber("test/pong", { handler: subscriber_callback });
+  session.declare_subscriber("test/pong", subscriber_callback);
 
   let count = 0;
   while (true) {

--- a/zenoh-ts/examples/deno/src/z_pub.ts
+++ b/zenoh-ts/examples/deno/src/z_pub.ts
@@ -45,7 +45,7 @@ export async function main() {
 
     console.warn("Block statement execution no : " + idx);
     console.warn(`Putting Data ('${key_expr}': '${buf}')...`);
-    publisher.put({ payload: buf, encoding: Encoding.TEXT_PLAIN, attachment: attach });
+    publisher.put(buf, { encoding: Encoding.TEXT_PLAIN, attachment: attach });
     await sleep(1000);
   }
 }

--- a/zenoh-ts/examples/deno/src/z_querier.ts
+++ b/zenoh-ts/examples/deno/src/z_querier.ts
@@ -39,7 +39,7 @@ export async function main() {
   for (let i = 0; i < 1000; i++) {
     await sleep(1000)
     const payload = "[" + i + "]" + _payload;
-    const receiver = querier.get({ payload: payload, parameters: selector.parameters() }) as Receiver;
+    const receiver = querier.get(selector.parameters(), { payload: payload }) as Receiver;
 
     let reply = await receiver.receive();
 

--- a/zenoh-ts/examples/deno/src/z_sub.ts
+++ b/zenoh-ts/examples/deno/src/z_sub.ts
@@ -28,7 +28,7 @@ export async function main() {
   const session = await Session.open(new Config("ws/127.0.0.1:10000"));
   const key_expr = new KeyExpr(key);
 
-  const poll_subscriber: Subscriber = session.declare_subscriber(key_expr, { handler: new RingChannel(10) });
+  const poll_subscriber: Subscriber = session.declare_subscriber(key_expr, new RingChannel(10));
 
   let sample = await poll_subscriber.receive();
 

--- a/zenoh-ts/examples/deno/src/z_sub_thr.ts
+++ b/zenoh-ts/examples/deno/src/z_sub_thr.ts
@@ -63,7 +63,7 @@ export async function main() {
   console.warn("Declare subscriber");
   session.declare_subscriber(
     "test/thr",
-    { handler: subscriber_callback }
+    subscriber_callback
   );
 
   let count = 0;

--- a/zenoh-ts/src/pubsub.ts
+++ b/zenoh-ts/src/pubsub.ts
@@ -190,7 +190,6 @@ export class FifoChannel implements Handler {
  * @param {IntoZBytes=} attachment - optional extra data to send with Payload
  */
 export interface PublisherPutOptions {
-  payload: IntoZBytes,
   encoding?: IntoEncoding,
   attachment?: IntoZBytes,
   timestamp?: Timestamp;
@@ -272,14 +271,16 @@ export class Publisher {
   /**
    * Puts a payload on the publisher associated with this class instance
    *
+   * @param {IntoZBytes} payload
    * @param {PublisherPutOptions} put_options
    *
    * @returns void
    */
   put(
+    payload: IntoZBytes,
     put_options: PublisherPutOptions,
   ): void {
-    let zbytes: ZBytes = new ZBytes(put_options.payload);
+    let zbytes: ZBytes = new ZBytes(payload);
     let _encoding;
     let _timestamp = null;
     if (put_options.timestamp != null) {

--- a/zenoh-ts/src/pubsub.ts
+++ b/zenoh-ts/src/pubsub.ts
@@ -278,23 +278,23 @@ export class Publisher {
    */
   put(
     payload: IntoZBytes,
-    put_options: PublisherPutOptions,
+    put_options?: PublisherPutOptions,
   ): void {
     let zbytes: ZBytes = new ZBytes(payload);
     let _encoding;
     let _timestamp = null;
-    if (put_options.timestamp != null) {
+    if (put_options?.timestamp != null) {
       _timestamp = put_options.timestamp.get_resource_uuid() as unknown as string;
     }
 
-    if (put_options.encoding != null) {
+    if (put_options?.encoding != null) {
       _encoding = Encoding.intoEncoding(put_options.encoding);
     } else {
       _encoding = Encoding.default();
     }
 
     let _attachment = null;
-    if (put_options.attachment != null) {
+    if (put_options?.attachment != null) {
       let att_bytes = new ZBytes(put_options.attachment);
       _attachment = Array.from(att_bytes.to_bytes());
     }

--- a/zenoh-ts/src/querier.ts
+++ b/zenoh-ts/src/querier.ts
@@ -117,7 +117,6 @@ export interface QuerierGetOptions {
   encoding?: Encoding,
   payload?: IntoZBytes,
   attachment?: IntoZBytes,
-  parameters?: Parameters
 }
 
 /**
@@ -206,7 +205,9 @@ export class Querier {
    * Issue a Get request on this querier
    * @returns Promise <Receiever | void>
    */
-  get(get_options?: QuerierGetOptions): Receiver | undefined {
+  get(
+    parameters?: Parameters,
+    get_options?: QuerierGetOptions): Receiver | undefined {
     if (this.undeclared == true) {
       return undefined;
     }
@@ -221,8 +222,8 @@ export class Querier {
     if (get_options?.payload != undefined) {
       _payload = Array.from(new ZBytes(get_options?.payload).to_bytes())
     }
-    if (get_options?.parameters != undefined) {
-      _parameters = get_options?.parameters.toString();
+    if (parameters != undefined) {
+      _parameters = parameters.toString();
     }
 
     let chan: SimpleChannel<ReplyWS> = this._remote_querier.get(

--- a/zenoh-ts/src/session.ts
+++ b/zenoh-ts/src/session.ts
@@ -123,12 +123,6 @@ export interface GetOptions {
 }
 
 /**
- * Options for a SubscriberOptions function 
-*/
-export interface SubscriberOptions {
-}
-
-/**
  * Options for a Queryable
  * @prop complete - Change queryable completeness.
  * @prop callback - Callback function for this queryable
@@ -454,8 +448,7 @@ export class Session {
   // Handler size : This is to match the API_DATA_RECEPTION_CHANNEL_SIZE of zenoh internally
   declare_subscriber(
     key_expr: IntoKeyExpr,
-    handler?: ((sample: Sample) => Promise<void>) | Handler,
-    _subscriber_opts?: SubscriberOptions
+    handler?: ((sample: Sample) => Promise<void>) | Handler
   ): Subscriber {
     let _key_expr = new KeyExpr(key_expr);
     let remote_subscriber: RemoteSubscriber;

--- a/zenoh-ts/src/session.ts
+++ b/zenoh-ts/src/session.ts
@@ -126,7 +126,6 @@ export interface GetOptions {
  * Options for a SubscriberOptions function 
 */
 export interface SubscriberOptions {
-  handler?: ((sample: Sample) => Promise<void>) | Handler,
 }
 
 /**
@@ -455,16 +454,14 @@ export class Session {
   // Handler size : This is to match the API_DATA_RECEPTION_CHANNEL_SIZE of zenoh internally
   declare_subscriber(
     key_expr: IntoKeyExpr,
-    subscriber_opts: SubscriberOptions
+    handler?: ((sample: Sample) => Promise<void>) | Handler,
+    _subscriber_opts?: SubscriberOptions
   ): Subscriber {
     let _key_expr = new KeyExpr(key_expr);
     let remote_subscriber: RemoteSubscriber;
 
     let callback_subscriber = false;
-    let handler;
-    if (subscriber_opts?.handler !== undefined) {
-      handler = subscriber_opts?.handler;
-    } else {
+    if (handler === undefined) {
       handler = new FifoChannel(256);
     }
     let [callback, handler_type] = this.check_handler_or_callback<Sample>(handler);


### PR DESCRIPTION
- `payload` is parameter of put in publisher
- `parameters` is parameter of get in querier
- `handler` is parameter of declare_subscriber