### PR TITLE
API alignment: handler is always in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The file `EXAMPLE_CONFIG.json5` references the `zenoh-plugin-remote-api\EXAMPLE_
    yarn build
    ```
 
-   The result are placed into the `zenoh-ts/dist` directory.
+   The result is placed into the `zenoh-ts/dist` directory.
 
    This library is currently compatible with browsers, but not with NodeJS due to websocket library limitations.
 

--- a/zenoh-ts/examples/deno/src/z_ping.ts
+++ b/zenoh-ts/examples/deno/src/z_ping.ts
@@ -18,7 +18,7 @@ import { Encoding, CongestionControl, Config, Session } from "@eclipse-zenoh/zen
 export async function main() {
   const session = await Session.open(new Config("ws/127.0.0.1:10000"));
 
-  const sub = session.declare_subscriber("test/pong", new FifoChannel(256) );
+  const sub = session.declare_subscriber("test/pong", { handler: new FifoChannel(256) } );
   const pub = session.declare_publisher(
     "test/ping",
     {

--- a/zenoh-ts/examples/deno/src/z_pong.ts
+++ b/zenoh-ts/examples/deno/src/z_pong.ts
@@ -29,7 +29,7 @@ export async function main() {
     pub.put(sample.payload());
   };
 
-  session.declare_subscriber("test/pong", subscriber_callback);
+  session.declare_subscriber("test/pong", { handler: subscriber_callback } );
 
   let count = 0;
   while (true) {

--- a/zenoh-ts/examples/deno/src/z_sub.ts
+++ b/zenoh-ts/examples/deno/src/z_sub.ts
@@ -24,7 +24,7 @@ export async function main() {
   const session = await Session.open(new Config("ws/127.0.0.1:10000"));
   const key_expr = new KeyExpr(args.key);
 
-  const poll_subscriber: Subscriber = session.declare_subscriber(key_expr, new RingChannel(10));
+  const poll_subscriber: Subscriber = session.declare_subscriber(key_expr, { handler: new RingChannel(10) });
 
   let sample = await poll_subscriber.receive();
 

--- a/zenoh-ts/examples/deno/src/z_sub_thr.ts
+++ b/zenoh-ts/examples/deno/src/z_sub_thr.ts
@@ -63,7 +63,7 @@ export async function main() {
   console.warn("Declare subscriber");
   session.declare_subscriber(
     "test/thr",
-    subscriber_callback
+    { handler: subscriber_callback }
   );
 
   let count = 0;

--- a/zenoh-ts/src/liveliness.ts
+++ b/zenoh-ts/src/liveliness.ts
@@ -25,12 +25,12 @@ function executeAsync(func: any) {
 }
 
 interface LivelinessSubscriberOptions {
-  callback?: (sample: Sample) => Promise<void>,
+  handler?: (sample: Sample) => Promise<void>, // TODO: add | Handler,
   history: boolean,
 }
 
 interface LivelinessGetOptions {
-  callback?: (reply: Reply) => Promise<void>,
+  handler?: (reply: Reply) => Promise<void>, // TODO: add | Handler,
   timeout?: TimeDuration,
 }
 
@@ -61,8 +61,8 @@ export class Liveliness {
     let remote_subscriber;
     let callback_subscriber = false;
 
-    if (options?.callback !== undefined) {
-      let callback = options?.callback;
+    if (options?.handler !== undefined) {
+      let callback = options?.handler;
       callback_subscriber = true;
       const callback_conversion = async function (sample_ws: SampleWS,): Promise<void> {
         let sample: Sample = Sample_from_SampleWS(sample_ws);
@@ -102,7 +102,7 @@ export class Liveliness {
 
     let receiver = Receiver.new(chan);
 
-    let callback = options?.callback;
+    let callback = options?.handler;
     if (callback !== undefined) {
       executeAsync(async () => {
         for await (const message of chan) {

--- a/zenoh-ts/src/session.ts
+++ b/zenoh-ts/src/session.ts
@@ -150,6 +150,14 @@ export interface PublisherOptions {
   reliability?: Reliability,
 }
 
+/**
+ * Options for a Subscriber
+ * @prop handler - Callback function for this subscriber
+ */
+export interface SubscriberOptions {
+  handler?: ((sample: Sample) => Promise<void>) | Handler,
+}
+
 // ███████ ███████ ███████ ███████ ██  ██████  ███    ██
 // ██      ██      ██      ██      ██ ██    ██ ████   ██
 // ███████ █████   ███████ ███████ ██ ██    ██ ██ ██  ██
@@ -422,20 +430,23 @@ export class Session {
    *  If a Subscriber is created with a callback, it cannot be simultaneously polled for new values
    * 
    * @param {IntoKeyExpr} key_expr - string of key_expression
-   * @param {((sample: Sample) => Promise<void>) | Handler} handler - Either a HandlerChannel or a Callback Function to be called for all samples
+   * @param {SubscriberOptions} subscriber_opts - Options for the subscriber, including a handler
    *
    * @returns Subscriber
    */
   // Handler size : This is to match the API_DATA_RECEPTION_CHANNEL_SIZE of zenoh internally
   declare_subscriber(
     key_expr: IntoKeyExpr,
-    handler?: ((sample: Sample) => Promise<void>) | Handler
+    subscriber_opts?: SubscriberOptions
   ): Subscriber {
     let _key_expr = new KeyExpr(key_expr);
     let remote_subscriber: RemoteSubscriber;
 
     let callback_subscriber = false;
-    if (handler === undefined) {
+    let handler;
+    if (subscriber_opts?.handler !== undefined) {
+      handler = subscriber_opts?.handler;
+    } else {
       handler = new FifoChannel(256);
     }
     let [callback, handler_type] = check_handler_or_callback<Sample>(handler);


### PR DESCRIPTION
There was an misalignment between API handler/callback parameter: 
- naming can be callback (for callback only items) or handler (for items which may accept callback or channel). This is wrong: even if at this moment the `callaback` parameter doesn't allow chanllel., it may/should support it in the future. Therefore parameter name should be `handler` 
- in `declare_subscriber` handler parameter was passed in arguments, while in other places it's passed in options. Made this uniform: now handler is always in options. (in fact this approach differs from the one in C++ which takes handler in parameters. But there is no function overloading in typescript, so approach with handler in options is better here)