### PR TITLE
Bump Rust toolchain to 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.85.0"

--- a/zenoh-plugin-remote-api/src/config.rs
+++ b/zenoh-plugin-remote-api/src/config.rs
@@ -58,7 +58,7 @@ where
 
 struct WebsocketVisitor;
 
-impl<'de> Visitor<'de> for WebsocketVisitor {
+impl Visitor<'_> for WebsocketVisitor {
     type Value = String;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Depends on https://github.com/eclipse-zenoh/zenoh/pull/1803