### PR TITLE
`Parameters` treated as string as in Rust, API corrected to match Rust one

### DIFF
--- a/zenoh-ts/src/query.ts
+++ b/zenoh-ts/src/query.ts
@@ -452,20 +452,29 @@ export class Parameters {
     
     return found;
   }
-
-  *keys(): Generator<string> {
-    for (const [keyStart, keyLen] of this._iter()) {
-      yield this._source.slice(keyStart, keyStart + keyLen);
+  /**
+   * gets an generator over the pairs (key,value) of the Parameters
+   * @returns Generator<string>
+   */
+  *iter(): Generator<[string, string]> {
+    for (const [keyStart, keyLen, valueStart, valueLen] of this._iter()) {
+      let key = this._source.slice(keyStart, keyStart + keyLen);
+      let value = valueStart >= 0 ? this._source.slice(valueStart, valueStart + valueLen) : '';
+      yield [key, value];
     }
   }
 
   /**
-   * gets an iterator over the values of the Parameters
-   * @returns Iterator<string>
+   * gets an generator over the values separated by `|`  in multivalue parameters
+   * @returns Generator<string>
    */
-  *values(): Generator<string> {
-    for (const [, , valueStart, valueLen] of this._iter()) {
-      yield valueStart >= 0 ? this._source.slice(valueStart, valueStart + valueLen) : '';
+  *values(key: string): Generator<string> {
+    let value = this.get(key);
+    if (value != undefined) {
+      let values = value.split('|');
+      for (const v of values) {
+        yield v;
+      }
     }
   }
 

--- a/zenoh-ts/src/query.ts
+++ b/zenoh-ts/src/query.ts
@@ -366,54 +366,57 @@ export type IntoParameters = Parameters | string | String | Map<string, string>
  * `let p = Parameters.new(a)`
  */
 export class Parameters {
-
-  private _params: Map<string, string>;
-
-  // constructor(p: Map<string, string>) {
-  //   this._params = p;
-  // }
+  private _source: string;
 
   constructor(p: IntoParameters) {
     if (p instanceof Parameters) {
-      this._params = p._params
+      this._source = p._source;
     } else if (p instanceof Map) {
-      this._params = p;
+      // Convert Map to string format
+      this._source = Array.from(p.entries())
+        .map(([k, v]) => `${k}=${v}`)
+        .join(';');
     } else {
-      const params = new Map<string, string>();
-      if (p.length != 0) {
-        for (const pair of p.split(";") || []) {
-          const [key, value] = pair.split("=");
-          if (key != undefined && value != undefined) {
-            params.set(key, value);
-          }
-        }
+      this._source = p.toString();
+    }
+  }
+
+  private *_iter(): Generator<[string, string]> {
+    if (this._source.length === 0) return;
+    
+    const pairs = this._source.split(';');
+    for (const pair of pairs) {
+      if (!pair) continue; // Skip empty segments
+      const eqIndex = pair.indexOf('=');
+      if (eqIndex === -1) {
+        // Handle parameter without value (equivalent to empty value)
+        yield [pair, ''];
+      } else {
+        const key = pair.slice(0, eqIndex);
+        const value = pair.slice(eqIndex + 1);
+        if (key) yield [key, value];
       }
-      this._params = params;
     }
   }
 
   /**
    * Creates empty Parameters Structs
-   * @returns void
+   * @returns Parameters
    */
-  static empty() {
-    return new Parameters("");
-  }
-
-  /**
-   * Creates empty Parameters Structs
-   * @returns void
-   */
-  static equals() {
+  static empty(): Parameters {
     return new Parameters("");
   }
 
   /**
    * removes a key from the parameters
-   * @returns void
+   * @returns boolean
    */
-  remove(key: string) {
-    return this._params.delete(key);
+  remove(key: string): boolean {
+    const entries = Array.from(this._iter());
+    const filteredEntries = entries.filter(([k]) => k !== key);
+    const hadKey = filteredEntries.length !== entries.length;
+    this._source = filteredEntries.map(([k, v]) => `${k}=${v}`).join(';');
+    return hadKey;
   }
 
   /**
@@ -421,7 +424,12 @@ export class Parameters {
    * @returns Iterator<string>
    */
   keys(): Iterator<string> {
-    return this._params.values()
+    const gen = function*(iter: Generator<[string, string]>): Generator<string> {
+      for (const [key] of iter) {
+        yield key;
+      }
+    }
+    return gen(this._iter());
   }
 
   /**
@@ -429,15 +437,26 @@ export class Parameters {
    * @returns Iterator<string>
    */
   values(): Iterator<string> {
-    return this._params.values()
+    const gen = function*(iter: Generator<[string, string]>): Generator<string> {
+      for (const [, value] of iter) {
+        yield value;
+      }
+    }
+    return gen(this._iter());
   }
 
   /**
-  * Returns true if properties does not contain anything.
-  * @returns void
-  */
+   * Returns true if properties does not contain anything.
+   * @returns boolean
+   */
   is_empty(): boolean {
-    return (this._params.size == 0);
+    // Quick check for empty string
+    if (!this._source) return true;
+    // Otherwise check if there are any valid entries
+    for (const _ of this._iter()) {
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -445,7 +464,10 @@ export class Parameters {
    * @returns boolean
    */
   contains_key(key: string): boolean {
-    return this._params.has(key)
+    for (const [k] of this._iter()) {
+      if (k === key) return true;
+    }
+    return false;
   }
 
   /**
@@ -453,42 +475,45 @@ export class Parameters {
    * @returns string | undefined
    */
   get(key: string): string | undefined {
-    return this._params.get(key)
+    for (const [k, v] of this._iter()) {
+      if (k === key) return v;
+    }
+    return undefined;
   }
 
   /**
    * Inserts new key,value pair into parameter
    * @returns void
    */
-  insert(key: string, value: string) {
-    return this._params.set(key, value);
+  insert(key: string, value: string): void {
+    const entries = Array.from(this._iter());
+    const index = entries.findIndex(([k]) => k === key);
+    if (index !== -1) {
+      entries[index] = [key, value];
+    } else {
+      entries.push([key, value]);
+    }
+    this._source = entries.map(([k, v]) => `${k}=${v}`).join(';');
   }
 
   /**
    * extends this Parameters with the value of other parameters, overwriting `this` if keys match.  
    * @returns void
    */
-  extend(other: IntoParameters) {
-    let other_params = new Parameters(other);
-    for (let [key, value] of other_params._params) {
-      this._params.set(key, value)
+  extend(other: IntoParameters): void {
+    const otherParams = new Parameters(other);
+    for (const [key, value] of otherParams._iter()) {
+      this.insert(key, value);
     }
   }
 
   /**
-   * returns the string representation of the 
-   * @returns void
+   * returns the string representation of the parameters
+   * @returns string
    */
   toString(): string {
-    let output_string = "";
-    for (let [key, value] of this._params) {
-      output_string += key + "=" + value + ";"
-    }
-    output_string = output_string.substring(0, output_string.length - 1);
-
-    return output_string;
+    return this._source;
   }
-
 }
 
 

--- a/zenoh-ts/src/query.ts
+++ b/zenoh-ts/src/query.ts
@@ -372,9 +372,9 @@ export class Parameters {
     if (p instanceof Parameters) {
       this._source = p._source;
     } else if (p instanceof Map) {
-      // Convert Map to string format
+      // Convert Map to string format, handling empty values
       this._source = Array.from(p.entries())
-        .map(([k, v]) => `${k}=${v}`)
+        .map(([k, v]) => v ? `${k}=${v}` : k)
         .join(';');
     } else {
       this._source = p.toString();
@@ -389,8 +389,7 @@ export class Parameters {
       if (!pair) continue; // Skip empty segments
       const eqIndex = pair.indexOf('=');
       if (eqIndex === -1) {
-        // Handle parameter without value (equivalent to empty value)
-        yield [pair, ''];
+        yield [pair, '']; // Handle parameter without value
       } else {
         const key = pair.slice(0, eqIndex);
         const value = pair.slice(eqIndex + 1);
@@ -465,7 +464,7 @@ export class Parameters {
    */
   contains_key(key: string): boolean {
     for (const [k] of this._iter()) {
-      if (k === key) return true;
+      if (k == key) return true;
     }
     return false;
   }
@@ -476,7 +475,7 @@ export class Parameters {
    */
   get(key: string): string | undefined {
     for (const [k, v] of this._iter()) {
-      if (k === key) return v;
+      if (k == key) return v;
     }
     return undefined;
   }
@@ -487,7 +486,7 @@ export class Parameters {
    */
   insert(key: string, value: string): void {
     const entries = Array.from(this._iter());
-    const index = entries.findIndex(([k]) => k === key);
+    const index = entries.findIndex(([k]) => k == key);
     if (index !== -1) {
       entries[index] = [key, value];
     } else {

--- a/zenoh-ts/tests/src/z_api_queryable_get.ts
+++ b/zenoh-ts/tests/src/z_api_queryable_get.ts
@@ -27,7 +27,7 @@ async function queryableSessionGetCallbackTest() {
     const queryable = session1.declare_queryable(ke_queryable, {
         handler: async (query: Query) => {
             queries.push(query);
-            if (query.parameters().toString() === "p=ok") {
+            if (query.parameters().toString() === "ok") {
                 let payload = query.payload() || "";
                 query.reply(query.key_expr(), payload);
             } else {
@@ -39,12 +39,9 @@ async function queryableSessionGetCallbackTest() {
     // sleep for 1 seconds to ensure the queryable is ready
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    // Similar test in C++ passes just "ok" in parameters, but this doesn't work in
-    // zenoh-ts due to https://github.com/eclipse-zenoh/zenoh-ts/issues/191
-    // TODO: restore just "ok" in parameters after fixing the issue
     const handler = async (reply: Reply) => { replies.push(reply); };
 
-    session2.get(new Selector(ke_get, "p=ok"), {
+    session2.get(new Selector(ke_get, "ok"), {
         payload: "1",
         handler: handler,
     });
@@ -52,7 +49,7 @@ async function queryableSessionGetCallbackTest() {
     // sleep to ensure the request is handled
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    session2.get(new Selector(ke_get, "p=err"), {
+    session2.get(new Selector(ke_get, "err"), {
         payload: "2",
         handler: handler,
     });
@@ -66,10 +63,10 @@ async function queryableSessionGetCallbackTest() {
     assert_eq(replies.length, 2, "Replies received");
 
     assert_eq(queries[0].key_expr().toString(), ke_get.toString(), "Query 0 key mismatch");
-    assert_eq(queries[0].parameters().toString(), "p=ok", "Query 0 parameters mismatch");
+    assert_eq(queries[0].parameters().toString(), "ok", "Query 0 parameters mismatch");
     assert_eq(queries[0].payload()?.to_string(), "1", "Query 0 payload mismatch");
     assert_eq(queries[1].key_expr().toString(), ke_get.toString(), "Query 1 key mismatch");
-    assert_eq(queries[1].parameters().toString(), "p=err", "Query 1 parameters mismatch");
+    assert_eq(queries[1].parameters().toString(), "err", "Query 1 parameters mismatch");
     assert_eq(queries[1].payload()?.to_string(), "2", "Query 1 payload mismatch");
     assert_eq(replies[0].result() instanceof Sample, true, "Reply 0 should be Sample");
     assert_eq(replies[1].result() instanceof ReplyError, true, "Reply 1 should be ReplyError");
@@ -93,15 +90,12 @@ async function queryableSessionGetChannelTest() {
 
     const queryable = await session1.declare_queryable(ke, { complete: true });
 
-    // Similar test in C++ passes just "ok" in parameters, but this doesn't work in
-    // zenoh-ts due to https://github.com/eclipse-zenoh/zenoh-ts/issues/191
-    // TODO: restore just "ok" in parameters after fixing the issue
-    const receiver1 = await session2.get(new Selector(selector, "p=ok"), { payload: "1" });
+    const receiver1 = await session2.get(new Selector(selector, "ok"), { payload: "1" });
     let query = await queryable.receive();
     assert_eq(query instanceof Query, true, "Expected query to be an instance of Query");
     if (query instanceof Query) {
         assert_eq(query.key_expr().toString(), selector.toString(), "Key mismatch");
-        assert_eq(query.parameters().toString(), "p=ok", "Parameters mismatch");
+        assert_eq(query.parameters().toString(), "ok", "Parameters mismatch");
         let decoder = new TextDecoder();
         assert_eq(query.payload()?.to_string(), "1", "Payload mismatch");
         query.reply(query.key_expr(), "1");
@@ -119,12 +113,12 @@ async function queryableSessionGetChannelTest() {
         }
     }
 
-    const receiver2 = await session2.get(new Selector(selector, "p=err"), { payload: "3" });
+    const receiver2 = await session2.get(new Selector(selector, "err"), { payload: "3" });
     query = await queryable.receive();
     assert_eq(query instanceof Query, true, "Expected query to be an instance of Query");
     if (query instanceof Query) {
         assert_eq(query.key_expr().toString(), selector.toString(), "Key mismatch");
-        assert_eq(query.parameters().toString(), "p=err", "Parameters mismatch");
+        assert_eq(query.parameters().toString(), "err", "Parameters mismatch");
         assert_eq(query.payload()?.to_string(), "3", "Payload mismatch");
         query.reply_err("err");
     }
@@ -164,12 +158,12 @@ async function queriableQuerierGetChannelTest() {
     });
 
     // First query with ok parameters
-    const receiver1 = await querier.get(new Parameters("p=ok"), { payload: "1" });
+    const receiver1 = await querier.get(new Parameters("ok"), { payload: "1" });
     let query = await queryable.receive();
     assert_eq(query instanceof Query, true, "Expected query to be an instance of Query");
     if (query instanceof Query) {
         assert_eq(query.key_expr().toString(), selector.toString(), "Key mismatch");
-        assert_eq(query.parameters().toString(), "p=ok", "Parameters mismatch");
+        assert_eq(query.parameters().toString(), "ok", "Parameters mismatch");
         assert_eq(query.payload()?.to_string(), "1", "Payload mismatch");
         query.reply(query.key_expr(), "1");
     }
@@ -190,12 +184,12 @@ async function queriableQuerierGetChannelTest() {
     }
 
     // Second query using the same querier with error parameters
-    const receiver2 = await querier.get(new Parameters("p=err"), { payload: "2" });
+    const receiver2 = await querier.get(new Parameters("err"), { payload: "2" });
     query = await queryable.receive();
     assert_eq(query instanceof Query, true, "Expected query to be an instance of Query");
     if (query instanceof Query) {
         assert_eq(query.key_expr().toString(), selector.toString(), "Key mismatch");
-        assert_eq(query.parameters().toString(), "p=err", "Parameters mismatch");
+        assert_eq(query.parameters().toString(), "err", "Parameters mismatch");
         assert_eq(query.payload()?.to_string(), "2", "Payload mismatch");
         query.reply_err("err");
     }
@@ -242,7 +236,7 @@ async function queriableQuerierGetCallbackTest() {
     const handler = async (reply: Reply) => { replies.push(reply); };
 
     // First query with ok parameters
-    querier.get(new Parameters("p=ok"), {
+    querier.get(new Parameters("ok"), {
         payload: "1",
         handler: handler
     });
@@ -255,13 +249,13 @@ async function queriableQuerierGetCallbackTest() {
     if (query instanceof Query) {
         queries.push(query);
         assert_eq(query.key_expr().toString(), selector.toString(), "Key mismatch");
-        assert_eq(query.parameters().toString(), "p=ok", "Parameters mismatch");
+        assert_eq(query.parameters().toString(), "ok", "Parameters mismatch");
         assert_eq(query.payload()?.to_string(), "1", "Payload mismatch");
         query.reply(query.key_expr(), "1");
     }
 
     // Second query using the same querier with error parameters
-    querier.get(new Parameters("p=err"), {
+    querier.get(new Parameters("err"), {
         payload: "2",
         handler: handler
     });
@@ -274,7 +268,7 @@ async function queriableQuerierGetCallbackTest() {
     if (query instanceof Query) {
         queries.push(query);
         assert_eq(query.key_expr().toString(), selector.toString(), "Key mismatch");
-        assert_eq(query.parameters().toString(), "p=err", "Parameters mismatch");
+        assert_eq(query.parameters().toString(), "err", "Parameters mismatch");
         assert_eq(query.payload()?.to_string(), "2", "Payload mismatch");
         query.reply_err("err");
     }

--- a/zenoh-ts/tests/src/z_keyexpr.ts
+++ b/zenoh-ts/tests/src/z_keyexpr.ts
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-import { Config, Session, KeyExpr, Parameters } from "@eclipse-zenoh/zenoh-ts";
+import { Config, Session, KeyExpr } from "@eclipse-zenoh/zenoh-ts";
 import { assert, assert_eq, run_test } from "./common/assertions.ts";
 
 export async function testKeyExprBasic() {
@@ -92,84 +92,6 @@ export async function testKeyExprDeclare() {
   await session.close();
 }
 
-export async function testParameters() {
-  // Test empty string initialization
-  const emptyParams = new Parameters("");
-  assert(emptyParams.is_empty(), "Empty string should create empty parameters");
-
-  // Test single parameter without value
-  const singleNoValue = new Parameters("p1");
-  const singleNoValueExpected = new Parameters("p1=");
-  assert_eq(singleNoValue.toString(), singleNoValueExpected.toString(), "Parameter without value should be equivalent to empty value");
-
-  // Test single parameter with value
-  const singleParam = new Parameters("p1=v1");
-  assert_eq(singleParam.get("p1"), "v1", "Single parameter with value not matched");
-
-  // Test multiple parameters with trailing semicolon
-  const multiParamTrailing = new Parameters("p1=v1;p2=v2;");
-  assert_eq(multiParamTrailing.get("p1"), "v1", "First parameter not matched");
-  assert_eq(multiParamTrailing.get("p2"), "v2", "Second parameter not matched");
-
-  // Test parameters with extra delimiters
-  const extraDelim = new Parameters("p1=v1;p2=v2;|=");
-  assert_eq(extraDelim.get("p1"), "v1", "Parameter p1 not matched with extra delimiters");
-  assert_eq(extraDelim.get("p2"), "v2", "Parameter p2 not matched with extra delimiters");
-
-  // Test mix of parameters with and without values
-  const mixedParams = new Parameters("p1=v1;p2;p3=v3");
-  assert_eq(mixedParams.get("p1"), "v1", "Parameter p1 not matched in mixed params");
-  assert_eq(mixedParams.get("p2"), "", "Parameter p2 should have empty value");
-  assert_eq(mixedParams.get("p3"), "v3", "Parameter p3 not matched in mixed params");
-
-  // Test parameters with spaces in values and keys
-  const spacedParams = new Parameters("p1=v 1;p 2=v2");
-  assert_eq(spacedParams.get("p1"), "v 1", "Parameter with space in value not matched");
-  assert_eq(spacedParams.get("p 2"), "v2", "Parameter with space in key not matched");
-
-  // Test parameters with equals signs in values
-  const equalsParams = new Parameters("p1=x=y;p2=a==b");
-  assert_eq(equalsParams.get("p1"), "x=y", "Parameter with equals in value not matched");
-  assert_eq(equalsParams.get("p2"), "a==b", "Parameter with multiple equals in value not matched");
-
-  // Test Map initialization
-  const map = new Map<string, string>();
-  map.set("p1", "v1");
-  const mapParams = new Parameters(map);
-  const stringParams = new Parameters("p1=v1");
-  assert_eq(mapParams.toString(), stringParams.toString(), "Map initialization not equivalent to string initialization");
-}
-
-export async function testParametersInsert() {
-  const params = Parameters.empty();
-  params.insert("key1", "value1");
-  assert_eq(params.get("key1"), "value1", "Parameter insert failed");
-}
-
-export async function testParametersExtend() {
-  const params1 = new Parameters("key1=value1");
-  const params2 = new Parameters("key2=value2;key1=updated");
-  
-  params1.extend(params2);
-  assert_eq(params1.get("key1"), "updated", "Parameter extend should update existing key");
-  assert_eq(params1.get("key2"), "value2", "Parameter extend should add new key");
-}
-
-export async function testParametersEmpty() {
-  const params = Parameters.empty();
-  assert(params.is_empty(), "Empty parameters should be empty");
-  params.insert("key1", "value1");
-  assert(!params.is_empty(), "Parameters with values should not be empty");
-}
-
-export async function testParametersDelete() {
-  const params = Parameters.empty();
-  params.insert("key1", "value1");
-  params.remove("key1");
-  
-  assert_eq(params.get("key1"), undefined, "Parameter removal failed");
-}
-
 // Run all tests
 await run_test(testKeyExprBasic);
 await run_test(testKeyExprCanonize);
@@ -179,8 +101,3 @@ await run_test(testKeyExprEquals);
 await run_test(testKeyExprIncludes);
 await run_test(testKeyExprIntersects);
 await run_test(testKeyExprDeclare);
-await run_test(testParameters);
-await run_test(testParametersInsert);
-await run_test(testParametersExtend);
-await run_test(testParametersEmpty);
-await run_test(testParametersDelete);

--- a/zenoh-ts/tests/src/z_keyexpr.ts
+++ b/zenoh-ts/tests/src/z_keyexpr.ts
@@ -93,15 +93,51 @@ export async function testKeyExprDeclare() {
 }
 
 export async function testParameters() {
-  // Test string initialization
-  const params = new Parameters("key1=value1;key2=value2");
-  assert_eq(params.get("key1"), "value1", "Parameter key1 value mismatch");
-  assert_eq(params.get("key2"), "value2", "Parameter key2 value mismatch");
-  assert_eq(params.get("nonexistent"), undefined, "Nonexistent parameter should return undefined");
+  // Test empty string initialization
+  const emptyParams = new Parameters("");
+  assert(emptyParams.is_empty(), "Empty string should create empty parameters");
 
-  // Test contains_key
-  assert(params.contains_key("key1"), "Parameter should contain key1");
-  assert(!params.contains_key("nonexistent"), "Parameter should not contain nonexistent key");
+  // Test single parameter without value
+  const singleNoValue = new Parameters("p1");
+  const singleNoValueExpected = new Parameters("p1=");
+  assert_eq(singleNoValue.toString(), singleNoValueExpected.toString(), "Parameter without value should be equivalent to empty value");
+
+  // Test single parameter with value
+  const singleParam = new Parameters("p1=v1");
+  assert_eq(singleParam.get("p1"), "v1", "Single parameter with value not matched");
+
+  // Test multiple parameters with trailing semicolon
+  const multiParamTrailing = new Parameters("p1=v1;p2=v2;");
+  assert_eq(multiParamTrailing.get("p1"), "v1", "First parameter not matched");
+  assert_eq(multiParamTrailing.get("p2"), "v2", "Second parameter not matched");
+
+  // Test parameters with extra delimiters
+  const extraDelim = new Parameters("p1=v1;p2=v2;|=");
+  assert_eq(extraDelim.get("p1"), "v1", "Parameter p1 not matched with extra delimiters");
+  assert_eq(extraDelim.get("p2"), "v2", "Parameter p2 not matched with extra delimiters");
+
+  // Test mix of parameters with and without values
+  const mixedParams = new Parameters("p1=v1;p2;p3=v3");
+  assert_eq(mixedParams.get("p1"), "v1", "Parameter p1 not matched in mixed params");
+  assert_eq(mixedParams.get("p2"), "", "Parameter p2 should have empty value");
+  assert_eq(mixedParams.get("p3"), "v3", "Parameter p3 not matched in mixed params");
+
+  // Test parameters with spaces in values and keys
+  const spacedParams = new Parameters("p1=v 1;p 2=v2");
+  assert_eq(spacedParams.get("p1"), "v 1", "Parameter with space in value not matched");
+  assert_eq(spacedParams.get("p 2"), "v2", "Parameter with space in key not matched");
+
+  // Test parameters with equals signs in values
+  const equalsParams = new Parameters("p1=x=y;p2=a==b");
+  assert_eq(equalsParams.get("p1"), "x=y", "Parameter with equals in value not matched");
+  assert_eq(equalsParams.get("p2"), "a==b", "Parameter with multiple equals in value not matched");
+
+  // Test Map initialization
+  const map = new Map<string, string>();
+  map.set("p1", "v1");
+  const mapParams = new Parameters(map);
+  const stringParams = new Parameters("p1=v1");
+  assert_eq(mapParams.toString(), stringParams.toString(), "Map initialization not equivalent to string initialization");
 }
 
 export async function testParametersInsert() {

--- a/zenoh-ts/tests/src/z_keyexpr.ts
+++ b/zenoh-ts/tests/src/z_keyexpr.ts
@@ -12,15 +12,15 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-import { Config, Session, KeyExpr } from "@eclipse-zenoh/zenoh-ts";
+import { Config, Session, KeyExpr, Parameters } from "@eclipse-zenoh/zenoh-ts";
 import { assert, assert_eq, run_test } from "./common/assertions.ts";
 
-export async function testKeyExpr() {
+export async function testKeyExprBasic() {
   const foo = new KeyExpr("FOO");
   assert(foo.toString() === "FOO", "KeyExpr string representation mismatch");
 }
 
-export async function testCanonize() {
+export async function testKeyExprCanonize() {
   const non_canon = "a/**/**/c";
   const canon = "a/**/c";
 
@@ -33,20 +33,20 @@ export async function testCanonize() {
   assert_eq(k_ok2.toString(), canon, "Re-canonization changed canonical form");
 }
 
-export async function testConcat() {
+export async function testKeyExprConcat() {
   const foo = new KeyExpr("FOO");
   const foobar = foo.concat("BAR");
   assert_eq(foobar.toString(), "FOOBAR", "Concatenation failed");
 }
 
-export async function testJoin() {
+export async function testKeyExprJoin() {
   const foo = new KeyExpr("FOO");
   const bar = new KeyExpr("BAR");
   const foobar = foo.join(bar);
   assert_eq(foobar.toString(), "FOO/BAR", "Join failed");
 }
 
-export async function testEquals() {
+export async function testKeyExprEquals() {
   const foo = new KeyExpr("FOO");
   const foo2 = new KeyExpr("FOO");
   const bar = new KeyExpr("BAR");
@@ -58,14 +58,14 @@ export async function testEquals() {
   assert(foo.toString() !== "BAR", "Expected foo != 'BAR'");
 }
 
-export async function testIncludes() {
+export async function testKeyExprIncludes() {
   const foostar = new KeyExpr("FOO/*");
   const foobar = new KeyExpr("FOO/BAR");
   assert(foostar.includes(foobar), "Expected FOO/* to include FOO/BAR");
   assert(!foobar.includes(foostar), "Expected FOO/BAR to not include FOO/*");
 }
 
-export async function testIntersects() {
+export async function testKeyExprIntersects() {
   const foostar = new KeyExpr("FOO/*");
   const foobar = new KeyExpr("FOO/BAR");
   const starbuz = new KeyExpr("*/BUZ");
@@ -77,7 +77,7 @@ export async function testIntersects() {
   assert(starbuz.intersects(foobuz), "Expected */BUZ to intersect with FOO/BUZ");
 }
 
-export async function testDeclare() {
+export async function testKeyExprDeclare() {
   const session = await Session.open(new Config("ws/127.0.0.1:10000"));
   
   const foobar = new KeyExpr("FOO/BAR");
@@ -92,12 +92,59 @@ export async function testDeclare() {
   await session.close();
 }
 
+export async function testParameters() {
+  // Test string initialization
+  const params = new Parameters("key1=value1;key2=value2");
+  assert_eq(params.get("key1"), "value1", "Parameter key1 value mismatch");
+  assert_eq(params.get("key2"), "value2", "Parameter key2 value mismatch");
+  assert_eq(params.get("nonexistent"), undefined, "Nonexistent parameter should return undefined");
+
+  // Test contains_key
+  assert(params.contains_key("key1"), "Parameter should contain key1");
+  assert(!params.contains_key("nonexistent"), "Parameter should not contain nonexistent key");
+}
+
+export async function testParametersInsert() {
+  const params = Parameters.empty();
+  params.insert("key1", "value1");
+  assert_eq(params.get("key1"), "value1", "Parameter insert failed");
+}
+
+export async function testParametersExtend() {
+  const params1 = new Parameters("key1=value1");
+  const params2 = new Parameters("key2=value2;key1=updated");
+  
+  params1.extend(params2);
+  assert_eq(params1.get("key1"), "updated", "Parameter extend should update existing key");
+  assert_eq(params1.get("key2"), "value2", "Parameter extend should add new key");
+}
+
+export async function testParametersEmpty() {
+  const params = Parameters.empty();
+  assert(params.is_empty(), "Empty parameters should be empty");
+  params.insert("key1", "value1");
+  assert(!params.is_empty(), "Parameters with values should not be empty");
+}
+
+export async function testParametersDelete() {
+  const params = Parameters.empty();
+  params.insert("key1", "value1");
+  params.remove("key1");
+  
+  assert_eq(params.get("key1"), undefined, "Parameter removal failed");
+}
+
 // Run all tests
-await run_test(testKeyExpr);
-await run_test(testCanonize);
-await run_test(testConcat);
-await run_test(testJoin);
-await run_test(testEquals);
-await run_test(testIncludes);
-await run_test(testIntersects);
-await run_test(testDeclare);
+await run_test(testKeyExprBasic);
+await run_test(testKeyExprCanonize);
+await run_test(testKeyExprConcat);
+await run_test(testKeyExprJoin);
+await run_test(testKeyExprEquals);
+await run_test(testKeyExprIncludes);
+await run_test(testKeyExprIntersects);
+await run_test(testKeyExprDeclare);
+await run_test(testParameters);
+await run_test(testParametersInsert);
+await run_test(testParametersExtend);
+await run_test(testParametersEmpty);
+await run_test(testParametersDelete);

--- a/zenoh-ts/tests/src/z_parameters.ts
+++ b/zenoh-ts/tests/src/z_parameters.ts
@@ -102,6 +102,25 @@ export async function testParametersDelete() {
   assert_eq(params.get("key1"), undefined, "Parameter removal failed");
 }
 
+export async function testParametersDuplicates() {
+  // Test duplicate handling in insert
+  const params = new Parameters("key1=value1;key2=value2;key1=duplicate");
+  assert_eq(params.get("key1"), "value1", "Should return first occurrence of key1");
+
+  // Test duplicate handling in remove
+  const params2 = new Parameters("key1=value1;key2=value2;key1=duplicate;key3=value3");
+  params2.remove("key1");
+  assert_eq(params2.toString(), "key2=value2;key3=value3", "Remove should remove all occurrences of key1");
+  assert_eq(params2.toString().split("key1").length - 1, 0, "Should have no occurrences of key1 after remove");
+  assert_eq(params2.get("key2"), "value2", "Other keys should remain intact");
+  assert_eq(params2.get("key3"), "value3", "Other keys should remain intact");
+
+  // Insert should overwrite all duplicates
+  params.insert("key1", "newvalue");
+  assert_eq(params.get("key1"), "newvalue", "Insert should remove duplicates");
+  assert_eq(params.toString().split("key1").length - 1, 1, "Should only have one occurrence of key1 after insert");
+}
+
 export async function testParametersPerformance() {
   const numOperations = 10000;
   const params = Parameters.empty();
@@ -145,4 +164,5 @@ await run_test(testParametersInsert);
 await run_test(testParametersExtend);
 await run_test(testParametersEmpty);
 await run_test(testParametersDelete);
-await run_test(testParametersPerformance);
+await run_test(testParametersDuplicates);
+// await run_test(testParametersPerformance);

--- a/zenoh-ts/tests/src/z_parameters.ts
+++ b/zenoh-ts/tests/src/z_parameters.ts
@@ -102,6 +102,41 @@ export async function testParametersDelete() {
   assert_eq(params.get("key1"), undefined, "Parameter removal failed");
 }
 
+export async function testParametersPerformance() {
+  const numOperations = 10000;
+  const params = Parameters.empty();
+  
+  // Test insert performance
+  const insertStart = performance.now();
+  for (let i = 0; i < numOperations; i++) {
+    params.insert(`key${i}`, `value${i}`);
+  }
+  const insertEnd = performance.now();
+  const insertTime = insertEnd - insertStart;
+  console.log(`Insert ${numOperations} parameters took ${insertTime.toFixed(2)}ms (${(insertTime/numOperations).toFixed(3)}ms per operation)`);
+
+  // Verify all insertions were successful
+  for (let i = 0; i < numOperations; i++) {
+    assert_eq(params.get(`key${i}`), `value${i}`, `Insert verification failed for key${i}`);
+  }
+
+  // Test remove performance
+  const removeStart = performance.now();
+  for (let i = 0; i < numOperations; i++) {
+    params.remove(`key${i}`);
+  }
+  const removeEnd = performance.now();
+  const removeTime = removeEnd - removeStart;
+  console.log(`Remove ${numOperations} parameters took ${removeTime.toFixed(2)}ms (${(removeTime/numOperations).toFixed(3)}ms per operation)`);
+
+  // Verify all removals were successful
+  for (let i = 0; i < numOperations; i++) {
+    assert_eq(params.get(`key${i}`), undefined, `Remove verification failed for key${i}`);
+  }
+
+  assert(params.is_empty(), "Parameters should be empty after removing all entries");
+}
+
 // Run all tests
 await run_test(testParametersBasic);
 await run_test(testParametersNonexistent);
@@ -110,3 +145,4 @@ await run_test(testParametersInsert);
 await run_test(testParametersExtend);
 await run_test(testParametersEmpty);
 await run_test(testParametersDelete);
+await run_test(testParametersPerformance);

--- a/zenoh-ts/tests/src/z_parameters.ts
+++ b/zenoh-ts/tests/src/z_parameters.ts
@@ -49,11 +49,37 @@ export async function testParametersBasic() {
   const equalsParams = new Parameters("p1=x=y;p2=a==b");
   assert_eq(equalsParams.get("p1"), "x=y", "Parameter with equals in value not matched");
   assert_eq(equalsParams.get("p2"), "a==b", "Parameter with multiple equals in value not matched");
+
+  // Test `values(key)` function
+  const mulitivalueParams = new Parameters("p1=v1|v2|v3|v4;p2=v5|v6|v7|v8");
+  assert_eq([...mulitivalueParams.values("p1")], ["v1", "v2", "v3", "v4"], "values() function not returning expected values");
+  assert_eq([...mulitivalueParams.values("p2")], ["v5", "v6", "v7", "v8"], "values() function not returning expected values");
 }
 
 export async function testParametersNonexistent() {
   const params = new Parameters("key1=value1");
   assert_eq(params.get("nonexistent"), undefined, "Nonexistent parameter should return undefined");
+}
+
+export async function testParametersIter() {
+  const map = new Map<string, string>();
+  map.set("p1", "v1");
+  map.set("p2", "v2");
+  map.set("p3", "v3");
+  const mapParams = new Parameters(map);
+  let count = 0;
+  for (const [key, value] of params.iter()) {
+    count++;
+    assert_eq(mapParams.get(key), value, `Iterated key ${key} does not match expected value ${value}`);
+  }
+  assert_eq(count, 3, "Iterating over parameters should yield 3 results");
+  // Test iterating over empty parameters
+  const emptyParams = new Parameters("");
+  let count0 = 0;
+  for (const _ of emptyParams.iter()) {
+    count0++;
+  }
+  assert_eq(count0, 0, "Iterating over empty parameters should yield no results");
 }
 
 export async function testParametersMap() {

--- a/zenoh-ts/tests/src/z_parameters.ts
+++ b/zenoh-ts/tests/src/z_parameters.ts
@@ -1,0 +1,110 @@
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+import { Parameters } from "@eclipse-zenoh/zenoh-ts";
+import { assert, assert_eq, run_test } from "./common/assertions.ts";
+
+export async function testParametersBasic() {
+  // Test empty string initialization
+  const emptyParams = new Parameters("");
+  assert(emptyParams.is_empty(), "Empty string should create empty parameters");
+
+  // Test single parameter without value
+  const singleNoValue = new Parameters("p1");
+  const singleNoValueExpected = new Parameters("p1=");
+  assert_eq(singleNoValue.toString(), singleNoValueExpected.toString(), "Parameter without value should be equivalent to empty value");
+
+  // Test single parameter with value
+  const singleParam = new Parameters("p1=v1");
+  assert_eq(singleParam.get("p1"), "v1", "Single parameter with value not matched");
+
+  // Test multiple parameters with trailing semicolon
+  const multiParamTrailing = new Parameters("p1=v1;p2=v2;");
+  assert_eq(multiParamTrailing.get("p1"), "v1", "First parameter not matched");
+  assert_eq(multiParamTrailing.get("p2"), "v2", "Second parameter not matched");
+
+  // Test parameters with extra delimiters
+  const extraDelim = new Parameters("p1=v1;p2=v2;|=");
+  assert_eq(extraDelim.get("p1"), "v1", "Parameter p1 not matched with extra delimiters");
+  assert_eq(extraDelim.get("p2"), "v2", "Parameter p2 not matched with extra delimiters");
+
+  // Test mix of parameters with and without values
+  const mixedParams = new Parameters("p1=v1;p2;p3=v3");
+  assert_eq(mixedParams.get("p1"), "v1", "Parameter p1 not matched in mixed params");
+  assert_eq(mixedParams.get("p2"), "", "Parameter p2 should have empty value");
+  assert_eq(mixedParams.get("p3"), "v3", "Parameter p3 not matched in mixed params");
+
+  // Test parameters with spaces in values and keys
+  const spacedParams = new Parameters("p1=v 1;p 2=v2");
+  assert_eq(spacedParams.get("p1"), "v 1", "Parameter with space in value not matched");
+  assert_eq(spacedParams.get("p 2"), "v2", "Parameter with space in key not matched");
+
+  // Test parameters with equals signs in values
+  const equalsParams = new Parameters("p1=x=y;p2=a==b");
+  assert_eq(equalsParams.get("p1"), "x=y", "Parameter with equals in value not matched");
+  assert_eq(equalsParams.get("p2"), "a==b", "Parameter with multiple equals in value not matched");
+}
+
+export async function testParametersNonexistent() {
+  const params = new Parameters("key1=value1");
+  assert_eq(params.get("nonexistent"), undefined, "Nonexistent parameter should return undefined");
+}
+
+export async function testParametersMap() {
+  // Test Map initialization
+  const map = new Map<string, string>();
+  map.set("p1", "v1");
+  const mapParams = new Parameters(map);
+  const stringParams = new Parameters("p1=v1");
+  assert_eq(mapParams.toString(), stringParams.toString(), "Map initialization not equivalent to string initialization");
+}
+
+export async function testParametersInsert() {
+  const params = Parameters.empty();
+  params.insert("key1", "value1");
+  assert_eq(params.get("key1"), "value1", "Parameter insert failed");
+}
+
+export async function testParametersExtend() {
+  const params1 = new Parameters("key1=value1");
+  const params2 = new Parameters("key2=value2;key1=updated");
+  
+  params1.extend(params2);
+  assert_eq(params1.get("key1"), "updated", "Parameter extend should update existing key");
+  assert_eq(params1.get("key2"), "value2", "Parameter extend should add new key");
+}
+
+export async function testParametersEmpty() {
+  const params = Parameters.empty();
+  assert(params.is_empty(), "Empty parameters should be empty");
+  params.insert("key1", "value1");
+  assert(!params.is_empty(), "Parameters with values should not be empty");
+}
+
+export async function testParametersDelete() {
+  const params = Parameters.empty();
+  params.insert("key1", "value1");
+  params.remove("key1");
+  
+  assert_eq(params.get("key1"), undefined, "Parameter removal failed");
+}
+
+// Run all tests
+await run_test(testParametersBasic);
+await run_test(testParametersNonexistent);
+await run_test(testParametersMap);
+await run_test(testParametersInsert);
+await run_test(testParametersExtend);
+await run_test(testParametersEmpty);
+await run_test(testParametersDelete);

--- a/zenoh-ts/tests/src/z_parameters.ts
+++ b/zenoh-ts/tests/src/z_parameters.ts
@@ -20,11 +20,6 @@ export async function testParametersBasic() {
   const emptyParams = new Parameters("");
   assert(emptyParams.is_empty(), "Empty string should create empty parameters");
 
-  // Test single parameter without value
-  const singleNoValue = new Parameters("p1");
-  const singleNoValueExpected = new Parameters("p1=");
-  assert_eq(singleNoValue.toString(), singleNoValueExpected.toString(), "Parameter without value should be equivalent to empty value");
-
   // Test single parameter with value
   const singleParam = new Parameters("p1=v1");
   assert_eq(singleParam.get("p1"), "v1", "Single parameter with value not matched");
@@ -68,6 +63,13 @@ export async function testParametersMap() {
   const mapParams = new Parameters(map);
   const stringParams = new Parameters("p1=v1");
   assert_eq(mapParams.toString(), stringParams.toString(), "Map initialization not equivalent to string initialization");
+
+  // Test parameter without value using Map
+  const singleNoValue = new Parameters("p1");
+  const emptyMap = new Map<string, string>();
+  emptyMap.set("p1", "");
+  const singleNoValueExpected = new Parameters(emptyMap);
+  assert_eq(singleNoValue.toString(), singleNoValueExpected.toString(), "Parameter without value should be equivalent to empty value");
 }
 
 export async function testParametersInsert() {


### PR DESCRIPTION
fix for #191:
- parameters are stored as original string, insert/remove methods updates this string, like in Rust
- tests for `Parameters` added
- metod `keys()` replaced to `iter()`, method `values(key)` returns `|`-separated values for key, like in Rust