### PR TITLE
remove unused text-encoding module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,37 +103,17 @@ jobs:
         with:
           deno-version: latest
 
+      - name: Verify build of zenoh-ts, tests and examples
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: build
+          dir: "zenoh-ts"
+
       - name: Run tests
         uses: borales/actions-yarn@v4
         with:
           cmd: start DAEMON test ALL
           dir: "zenoh-ts"
-      
-      # zenoh-ts is already built by test script, so we need only to install
-      # it into corresponding examples directories to check if examples compiles
-      - name: Install dependencies for deno examples
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
-          dir: "zenoh-ts/examples/deno"
-        
-      - name: Verify build for deno examples
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: verify
-          dir: "zenoh-ts/examples/deno"
- 
-      - name: Install dependencies for chat example
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
-          dir: "zenoh-ts/examples/browser/chat"
-
-      - name: Verify build for chat example
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: build
-          dir: "zenoh-ts/examples/browser/chat"
 
   markdown_lint:
     runs-on: ubuntu-latest

--- a/zenoh-ts/examples/browser/chat/yarn.lock
+++ b/zenoh-ts/examples/browser/chat/yarn.lock
@@ -14,7 +14,6 @@
     base64-arraybuffer "^1.0.2"
     channel-ts "^0.1.2"
     eslint "^9.10.0"
-    text-encoding "^0.7.0"
     tslog "^4.9.3"
     typed-duration "^2.0.0"
     uuid "^10.0.0"
@@ -2509,11 +2508,6 @@ terser@^5.31.1:
     acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
-
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 thunky@^1.0.2:
   version "1.1.0"

--- a/zenoh-ts/examples/deno/yarn.lock
+++ b/zenoh-ts/examples/deno/yarn.lock
@@ -3,13 +3,12 @@
 
 
 "@eclipse-zenoh/zenoh-ts@file:../..":
-  version "1.1.1"
+  version "1.3.4"
   dependencies:
     "@thi.ng/leb128" "^3.1.36"
     base64-arraybuffer "^1.0.2"
     channel-ts "^0.1.2"
     eslint "^9.10.0"
-    text-encoding "^0.7.0"
     tslog "^4.9.3"
     typed-duration "^2.0.0"
     uuid "^10.0.0"
@@ -695,11 +694,6 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
-
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 text-table@^0.2.0:
   version "0.2.0"

--- a/zenoh-ts/package.json
+++ b/zenoh-ts/package.json
@@ -27,7 +27,6 @@
     "base64-arraybuffer": "^1.0.2",
     "channel-ts": "^0.1.2",
     "eslint": "^9.10.0",
-    "text-encoding": "^0.7.0",
     "tslog": "^4.9.3",
     "typed-duration": "^2.0.0",
     "uuid": "^10.0.0"

--- a/zenoh-ts/scripts/build.sh
+++ b/zenoh-ts/scripts/build.sh
@@ -19,4 +19,22 @@ cd "$SCRIPTDIR/.."
 npx tsc || exit 1
 cp ./src/key_expr/*wasm* ./dist/key_expr/
 
+# build tests
+cd tests
+yarn install || exit 1
+yarn verify || exit 1
+cd "$SCRIPTDIR/.."
+
+# build examples/deno
+cd examples/deno
+yarn install || exit 1
+yarn verify || exit 1
+cd "$SCRIPTDIR/.."
+
+# build examples/browser
+cd examples/browser/chat
+yarn install || exit 1
+yarn build || exit 1
+cd "$SCRIPTDIR/.."
+
 cd "$ORIGINAL_DIR"

--- a/zenoh-ts/tests/yarn.lock
+++ b/zenoh-ts/tests/yarn.lock
@@ -3,13 +3,12 @@
 
 
 "@eclipse-zenoh/zenoh-ts@file:..":
-  version "1.2.1"
+  version "1.3.4"
   dependencies:
     "@thi.ng/leb128" "^3.1.36"
     base64-arraybuffer "^1.0.2"
     channel-ts "^0.1.2"
     eslint "^9.10.0"
-    text-encoding "^0.7.0"
     tslog "^4.9.3"
     typed-duration "^2.0.0"
     uuid "^10.0.0"
@@ -703,11 +702,6 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
-
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 tslib@^2.8.1:
   version "2.8.1"

--- a/zenoh-ts/yarn.lock
+++ b/zenoh-ts/yarn.lock
@@ -1000,11 +1000,6 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
-
 trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz"


### PR DESCRIPTION
fixes #214 
- unused and deprecated text-encoding module removed
- build command builds tests and examples also
- ci simplified