### PR TITLE
ci: add step to setup deno

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
           cmd: install
           dir: ./zenoh-ts
 
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - name: Transpile Code
         working-directory: ./zenoh-ts
         run: |


### PR DESCRIPTION
New GH runner image doesn't seem to have it installed. Fix https://github.com/eclipse-zenoh/zenoh-ts/actions/runs/15057873841/job/42327445034