### PR TITLE
Encoding.withSchema behaviour made the same as in other implementations

### DIFF
--- a/zenoh-ts/scripts/start.sh
+++ b/zenoh-ts/scripts/start.sh
@@ -41,7 +41,7 @@ stop_daemon() {
   fi
 }
 
-run build if needed
+# run build if needed
 if [ ! -d "./dist" ]; then
   yarn build library || exit 1
 fi

--- a/zenoh-ts/src/encoding.ts
+++ b/zenoh-ts/src/encoding.ts
@@ -76,8 +76,13 @@ export type IntoEncoding = Encoding | String | string;
 export class Encoding {
   private constructor(private strRep: string) {}
 
-  withSchema(input: string){
-    this.strRep = input;
+  withSchema(input: string): Encoding {
+    const idx = this.strRep.indexOf(";");
+    if (idx === -1) {
+      return new Encoding(this.strRep + ";" + input);
+    } else {
+      return new Encoding(this.strRep.substring(0, idx+1) + input);
+    }
   }
 
   static default(): Encoding {

--- a/zenoh-ts/tests/src/z_encoding.ts
+++ b/zenoh-ts/tests/src/z_encoding.ts
@@ -21,6 +21,7 @@ Deno.test("Encoding - Basic", () => {
     assertEquals(Encoding.default().withSchema("foobar").toString(), "zenoh/bytes;foobar");
     assertEquals(Encoding.TEXT_PLAIN.toString(), "text/plain");
     assertEquals(Encoding.TEXT_PLAIN.withSchema("charset=utf-8").toString(), "text/plain;charset=utf-8");
+    assertEquals(Encoding.fromString("text/plain;charset=utf-8").withSchema("charset=ascii").toString(), "text/plain;charset=ascii");
     assertEquals(Encoding.fromString("zenoh/bytes"), Encoding.ZENOH_BYTES);
     assertEquals(Encoding.fromString("zenoh/bytes;foobar").toString(), "zenoh/bytes;foobar");
     assertEquals(Encoding.fromString("custom/encoding").toString(), "custom/encoding");

--- a/zenoh-ts/tests/src/z_encoding.ts
+++ b/zenoh-ts/tests/src/z_encoding.ts
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import { Encoding } from "@eclipse-zenoh/zenoh-ts";
+
+Deno.test("Encoding - Basic", () => {
+    assertEquals(Encoding.default(), Encoding.ZENOH_BYTES);
+    assertEquals(Encoding.default().toString(), "zenoh/bytes");
+    assertEquals(Encoding.default().withSchema("foobar").toString(), "zenoh/bytes;foobar");
+    assertEquals(Encoding.TEXT_PLAIN.toString(), "text/plain");
+    assertEquals(Encoding.TEXT_PLAIN.withSchema("charset=utf-8").toString(), "text/plain;charset=utf-8");
+    assertEquals(Encoding.fromString("zenoh/bytes"), Encoding.ZENOH_BYTES);
+    assertEquals(Encoding.fromString("zenoh/bytes;foobar").toString(), "zenoh/bytes;foobar");
+    assertEquals(Encoding.fromString("custom/encoding").toString(), "custom/encoding");
+    assertEquals(Encoding.fromString("custom/encoding;foobar"), Encoding.fromString("custom/encoding").withSchema("foobar"));
+});


### PR DESCRIPTION
- `Encoding.withSchema` returns new Encoding instance with schema part added
- test added
fix for #227 