### PR TITLE
yarn build script builds library by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,15 @@ and daemon from the sources and start it.
 
    ```sh
    yarn install 
-   yarn build library
+   yarn build
    ```
 
    The result is placed into the `zenoh-ts/dist` directory.
+
+   Note: `yarn build` defaults to building the library. You can also specify
+   components explicitly: `yarn build library`, `yarn build tests`,
+   `yarn build examples`, or `yarn build ALL` for everything. See all options available by
+   `yarn build --help`
 
    This library is currently compatible with browsers, but not with NodeJS due
    to websocket library limitations.

--- a/zenoh-ts/scripts/build.sh
+++ b/zenoh-ts/scripts/build.sh
@@ -6,8 +6,11 @@ cd "$SCRIPTDIR/.."
 
 # Print usage info
 print_usage() {
-    echo "Usage: yarn build <component> [subcomponent]"
-    echo "Components:"
+    echo "Usage: yarn build [component] [subcomponent]"
+    echo "Options:"
+    echo "  --help     - Show this help message"
+    echo ""
+    echo "Components (default: library):"
     echo "  library    - Build only library (WASM module and TypeScript)"
     echo "  tests      - Build only tests"
     echo "  examples   - Build only examples"
@@ -15,6 +18,8 @@ print_usage() {
     echo "    deno     - Build only Deno examples"
     echo "    browser  - Build only browser examples"
     echo "  ALL        - Build everything"
+    echo ""
+    echo "If no component is specified, builds the library by default."
 }
 
 # Install common dependencies
@@ -94,10 +99,15 @@ build_examples() {
 # Process command line arguments
 component="$1"
 
-# If no parameters passed, show help
-if [ -z "$component" ]; then
+# Check for help flag
+if [ "$component" = "--help" ] || [ "$component" = "-h" ]; then
     print_usage
     exit 0
+fi
+
+# If no parameters passed, build library by default
+if [ -z "$component" ]; then
+    component="library"
 fi
 
 subcomponent="$2"


### PR DESCRIPTION
- restored old behavior of build script: it's more convenient to the user as it's default for most of ts projects