### PR TITLE
do not explicily set verion of zenoh-plugin-remote-api package available by path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh.git", branc
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", version = "1.4.0" }
 zenoh-result = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", version = "1.4.0" }
 zenoh-keyexpr = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", version = "1.4.0" }
-zenoh-plugin-remote-api = { path = "zenoh-plugin-remote-api", version = "1.4.0" }
+zenoh-plugin-remote-api = { path = "zenoh-plugin-remote-api" }
 
 uuid = { version = "1.17.0", default-features = false, features = [
     "v4",


### PR DESCRIPTION
The version of zenoh-plugin-remote-api is updated by ci/scripts/bump-and-tag.bash script, see e.g. commint https://github.com/eclipse-zenoh/zenoh-ts/commit/2bbc4d75a0e9cf9b04f7c39700037941d91f626e.
This causes version incompatibility error: https://github.com/eclipse-zenoh/zenoh-ts/actions/runs/15746475056/job/44383638351

The fix removes explicit version of dependency of zenoh-plugin-remote-api to avoid this