### PR TITLE
ci: fix CI failures with reference to deno

### DIFF
--- a/zenoh-ts/src/index.ts
+++ b/zenoh-ts/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference lib="deno.ns" />
 //
 // Copyright (c) 2023 ZettaScale Technology
 //

--- a/zenoh-ts/tests/src/bench/z_serialization.ts
+++ b/zenoh-ts/tests/src/bench/z_serialization.ts
@@ -1,3 +1,4 @@
+/// <reference lib="deno.ns" />
 // Copyright (c) 2025 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the

--- a/zenoh-ts/tests/src/z_timestamp.ts
+++ b/zenoh-ts/tests/src/z_timestamp.ts
@@ -1,3 +1,4 @@
+/// <reference lib="deno.ns" />
 //
 // Copyright (c) 2025 ZettaScale Technology
 //


### PR DESCRIPTION
Suggested by the tooling itself as part of the error