### PR TITLE
chore: use correct repository url for publication

### DIFF
--- a/zenoh-ts/package.json
+++ b/zenoh-ts/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/eclipse-zenoh/zenoh-ts"
+    "url": "https://github.com/eclipse-zenoh/zenoh-ts"
   },
   "keywords": [
     "networking"


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/zenoh-ts/actions/runs/20022693840/job/57413382422