### PR TITLE
:bug: Fix retry loop in RemoteLink websocket reconnect logic

### DIFF
--- a/zenoh-ts/src/link.ts
+++ b/zenoh-ts/src/link.ts
@@ -56,7 +56,7 @@ export class RemoteLink {
         console.warn("Connected to", websocketEndpoint);
         return new RemoteLink(ws);
       } else {
-        ws = new WebSocket(websocketEndpoint);
+        retries++;
         console.warn("Restart connection");
       }
     }


### PR DESCRIPTION
This PR fixes an issue in RemoteLink where the WebSocket reconnect loop never terminates because the retries counter was never incremented.

- Added retries++ inside the retry loop.