### PR TITLE
fix(zenoh): close failed WebSocket before retrying connection

### DIFF
--- a/zenoh-ts/src/link.ts
+++ b/zenoh-ts/src/link.ts
@@ -56,6 +56,8 @@ export class RemoteLink {
         console.warn("Connected to", websocketEndpoint);
         return new RemoteLink(ws);
       } else {
+        ws.close();
+        retries++;
         ws = new WebSocket(websocketEndpoint);
         console.warn("Restart connection");
       }


### PR DESCRIPTION
# Description
This PR fixes a WebSocket resource leak in `link.ts` by ensuring failed WebSocket connections are properly closed before retrying.

# What does this PR do?
Updates `RemoteLink.new()` retry logic to close the failed `WebSocket` instance before creating a new one
Increments the retry counter during the failed connection branch

# Why is this change needed?
Without closing failed WebSocket handles, retry attempts could leave dangling connections open. This caused flaky CI test failures due to resource leaks detected by Deno’s test harness.
