### PR TITLE
chore: update workspace members to inherit values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
-members = ["zenoh-plugin-remote-api", "zenoh-bridge-remote-api", "zenoh-keyexpr-wasm"]
+members = [
+    "zenoh-plugin-remote-api",
+    "zenoh-bridge-remote-api",
+    "zenoh-keyexpr-wasm",
+]
 resolver = "1"
 
 [workspace.package]
@@ -11,6 +15,7 @@ edition = "2021"
 license = "EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Remote API Plugin for Zenoh using Websockets"
+rust-version = "1.75.0"
 
 [workspace.dependencies]
 async-liveliness-monitor = "0.1.1"
@@ -31,13 +36,13 @@ lru = "0.14.0"
 tracing = "0.1.41"
 schemars = { version = "0.8.21" } # do not switch to 0.9, it's not supported by rust 1.75
 serde = { version = "1.0.219", default-features = false, features = [
-  "derive",
+    "derive",
 ] } # Default features are disabled due to usage in no_std crates
 serde_json = "1.0.140"
 jsonschema = { version = "0.18.0", default-features = false }
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
     "internal",
-    "plugins", 
+    "plugins",
     "unstable",
 ], version = "1.9.0" }
 zenoh-ext = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", version = "1.9.0" }

--- a/zenoh-bridge-remote-api/Cargo.toml
+++ b/zenoh-bridge-remote-api/Cargo.toml
@@ -12,20 +12,15 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.75.0"
+rust-version = { workspace = true }
 name = "zenoh-bridge-remote-api"
-version = "1.4.0"
+version = { workspace = true }
 repository = "https://github.com/eclipse-zenoh/zenoh-ts"
 homepage = "http://zenoh.io"
-authors = [
-    "Michael Ilyin <michael.ilyin@zettascale.tech>",
-]
-edition = "2021"
+authors = ["Michael Ilyin <michael.ilyin@zettascale.tech>"]
+edition = { workspace = true }
 license = "EPL-2.0 OR Apache-2.0"
-categories = [
-    "network-programming",
-    "web-programming::websocket",
-]
+categories = ["network-programming", "web-programming::websocket"]
 description = "Zenoh: The Zero Overhead Pub/Sub/Query Protocol."
 
 [features]
@@ -60,12 +55,12 @@ zenoh-ext = { workspace = true }
 zenoh-plugin-trait = { workspace = true }
 zenoh-util = { workspace = true }
 zenoh-result = { workspace = true }
-zenoh-plugin-remote-api = {workspace = true }
-uuid = { workspace=true, default-features = false, features = [
+zenoh-plugin-remote-api = { workspace = true }
+uuid = { workspace = true, default-features = false, features = [
     "v4",
     "serde",
 ] }
-uhlc = { workspace=true, default-features = false } # Default features are disabled due to usage in no_std crates
+uhlc = { workspace = true, default-features = false } # Default features are disabled due to usage in no_std crates
 lru = { workspace = true }
 
 [build-dependencies]
@@ -81,4 +76,4 @@ maintainer = "zenoh-dev@eclipse.org"
 copyright = "2024 ZettaScale Technology"
 section = "net"
 license-file = ["../zenoh-ts/LICENSE", "0"]
-depends = "zenohd (=1.4.0)"
+depends = "zenohd (=1.9.0)"

--- a/zenoh-keyexpr-wasm/Cargo.toml
+++ b/zenoh-keyexpr-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zenoh-keyexpr-wasm"
-version = "0.1.0"
+version = { workspace = true }
 authors = ["Charles Schleich"]
-edition = "2018"
+edition = { workspace = true }
 publish = false
 description = "A wrapper for zenoh-keyexpr for use with WebAssembly."
 repository = "https://github.com/eclipse-zenoh/zenoh-ts"
@@ -16,13 +16,13 @@ default = []
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-zenoh-keyexpr = { workspace = true, features = [
-    "js",
-] }
+zenoh-keyexpr = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"
 
 # Disable warninng `unexpected `cfg` condition name: `wasm_bindgen_unstable_test_coverage``
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(wasm_bindgen_unstable_test_coverage)',
+] }

--- a/zenoh-plugin-remote-api/Cargo.toml
+++ b/zenoh-plugin-remote-api/Cargo.toml
@@ -12,9 +12,9 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.75.0"
+rust-version = { workspace = true }
 name = "zenoh-plugin-remote-api"
-version = "1.9.0"
+version = { workspace = true }
 repository = "https://github.com/eclipse-zenoh/zenoh-ts"
 homepage = "http://zenoh.io"
 authors = [
@@ -23,12 +23,9 @@ authors = [
     "Luca Cominardi <luca.cominardi@zettascale.tech>",
     "Pierre Avital <pierre.avital@zettascale.tech>",
 ]
-edition = "2021"
+edition = { workspace = true }
 license = "EPL-2.0 OR Apache-2.0"
-categories = [
-    "network-programming",
-    "web-programming::websocket",
-]
+categories = ["network-programming", "web-programming::websocket"]
 description = "Zenoh: The Zero Overhead Pub/Sub/Query Protocol."
 
 [features]
@@ -62,11 +59,11 @@ zenoh-ext = { workspace = true }
 zenoh-plugin-trait = { workspace = true }
 zenoh-util = { workspace = true }
 zenoh-result = { workspace = true }
-uuid = { workspace=true, default-features = false, features = [
+uuid = { workspace = true, default-features = false, features = [
     "v4",
     "serde",
 ] }
-uhlc = { workspace=true, default-features = false } # Default features are disabled due to usage in no_std crates
+uhlc = { workspace = true, default-features = false } # Default features are disabled due to usage in no_std crates
 lru = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
zenoh-bridge-remote-api, zenoh-keyexpr-wasm and zenoh-plugin-remote-api are workspace members so they should inherit the version/edition/rust-version values from the root Cargo.toml