### PR TITLE
remote-api: log WebSocket forwarding failures

### DIFF
--- a/zenoh-plugin-remote-api/src/lib.rs
+++ b/zenoh-plugin-remote-api/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use futures::{future, pin_mut, SinkExt, StreamExt, TryStreamExt};
+use futures::{future, future::Either, pin_mut, SinkExt, StreamExt, TryStreamExt};
 use interface::{InRemoteMessage, OutRemoteMessage, SequenceId};
 use remote_state::RemoteState;
 use rustls_pemfile::{certs, private_key};
@@ -580,7 +580,15 @@ async fn run_websocket_server(
             });
 
             pin_mut!(ch_rx_stream, incoming_ws);
-            future::select(ch_rx_stream, incoming_ws).await;
+            match future::select(ch_rx_stream, incoming_ws).await {
+                Either::Left((Err(err), _)) => {
+                    tracing::warn!("WebSocket forwarding failed: {err}");
+                }
+                Either::Right((Err(err), _)) => {
+                    tracing::warn!("WebSocket receive task failed: {err}");
+                }
+                _ => {}
+            }
 
             // cleanup state
             state_map2.write().await.remove(&id.to_string());


### PR DESCRIPTION
## Summary
Log the result of whichever WebSocket task completes first.

A forwarding error was previously discarded by the select operation, leaving a clean-looking disconnect log even when the write side had failed.

## Verification
- cargo fmt --check
- cargo check -p zenoh-plugin-remote-api

This is intentionally scoped to observability; it does not change forwarding or reconnect behavior.